### PR TITLE
updating vulnerable packages

### DIFF
--- a/.github/workflows/ci-documentation.yml
+++ b/.github/workflows/ci-documentation.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node 🔧
         uses: actions/setup-node@v1
         with:
-          node-version: "16.x"
+          node-version: "20.x"
           cache: "npm"
           cache-dependency-path: ./docs/package-lock.json
           path: $DOC_FOLDER

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           dotnet-version: ${{ matrix.dotnet-version }}
 
       - name: Setup Stryker 🔧
-        run: dotnet tool install -g dotnet-stryker --version 4.0.0
+        run: dotnet tool install -g dotnet-stryker --version 3.13.2
 
       - name: Install dotnet-format tool 🔧
         run: dotnet tool install -g dotnet-format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           dotnet-version: ${{ matrix.dotnet-version }}
 
       - name: Setup Stryker 🔧
-        run: dotnet tool install -g dotnet-stryker
+        run: dotnet tool install -g dotnet-stryker --version 4.0.0
 
       - name: Install dotnet-format tool 🔧
         run: dotnet tool install -g dotnet-format

--- a/docs/docs/mapping-string-into-type.md
+++ b/docs/docs/mapping-string-into-type.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # Type Parser
 
-If you require extracting positional strings and converting the values into their final forms, such as obtaining a string representing a datetime or currency, you can create an interceptor reader by implementing the `ITypeParser` interface. This allows you to perform custom actions before the value is set to the final property.
+If you require extracting positional strings and converting the values into their final forms, such as obtaining a string representing a datetime or decimal currency format, you can create an interceptor reader by implementing the `ITypeParser` interface. This allows you to perform custom actions before the value is set to the final property.
 
 here and example of intercept the property read.
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,16 +14,16 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.2.0",
-    "@docusaurus/plugin-google-gtag": "^2.2.0",
-    "@docusaurus/preset-classic": "^2.2.0",
+    "@docusaurus/core": "^3.1.0",
+    "@docusaurus/plugin-google-gtag": "^3.1.0",
+    "@docusaurus/preset-classic": "^3.1.0",
     "@mdx-js/react": "^1.6.21",
-    "@svgr/webpack": "^5.5.0",
+    "@svgr/webpack": "^8.1.0",
     "clsx": "^1.1.1",
     "file-loader": "^6.2.0",
     "prism-react-renderer": "^1.2.1",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
+    "react": "^18.0.1",
+    "react-dom": "^18.0.1",
     "url-loader": "^4.1.1"
   },
   "browserslist": {


### PR DESCRIPTION
* Updating npm package from docusaurus.
* Add stryker version to be not conflitate with dotnet 7 version, new versions of stryker is only compatible with dotnet 8.
* Update node version of ci-documentation